### PR TITLE
Eliminate warnings and improve .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,118 +1,15 @@
-# Created by https://www.gitignore.io/api/java,gradle,eclipse,intellij
-
-### Java ###
-*.class
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
-# Package Files #
-*.jar
-*.war
-*.ear
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
-
-
-### Gradle ###
-.gradle
-build/
-
-# Ignore Gradle GUI config
-gradle-app.setting
-
-# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
-!gradle-wrapper.jar
-
-
-### Eclipse ###
-*.pydevproject
-.metadata
-.gradle
-bin/
-tmp/
-*.tmp
-*.bak
-*.swp
-*~.nib
-local.properties
-.settings/
-.loadpath
-
-# Eclipse Core
-.project
-
-# External tool builders
-.externalToolBuilders/
-
-# Locally stored "Eclipse launch configurations"
-*.launch
-
-# CDT-specific
-.cproject
-
-# JDT-specific (Eclipse Java Development Tools)
+# Eclipse
 .classpath
-
-# Java annotation processor (APT)
-.factorypath
-
-# PDT-specific
-.buildpath
-
-# sbteclipse plugin
-.target
-
-# TeXlipse plugin
-.texlipse
-
-
-### Intellij ###
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
-
-*.iml
-
-## Directory-based project format:
-.idea/
-# if you remove the above rule, at least ignore the following:
-
-# User-specific stuff:
-# .idea/workspace.xml
-# .idea/tasks.xml
-# .idea/dictionaries
-
-# Sensitive or high-churn files:
-# .idea/dataSources.ids
-# .idea/dataSources.xml
-# .idea/sqlDataSources.xml
-# .idea/dynamic.xml
-# .idea/uiDesigner.xml
-
-# Gradle:
-# .idea/gradle.xml
-# .idea/libraries
-
-# Mongo Explorer plugin:
-# .idea/mongoSettings.xml
-
-## File-based project format:
-*.ipr
-*.iws
-
-## Plugin-specific files:
+.project
+.settings/
+.metadata/
+bin/
 
 # IntelliJ
-/out/
+*.iml
+*.ipr
+.idea/
 
-# mpeltonen/sbt-idea plugin
-.idea_modules/
-
-# JIRA plugin
-atlassian-ide-plugin.xml
-
-# Crashlytics plugin (for Android Studio and IntelliJ)
-com_crashlytics_export_strings.xml
-crashlytics.properties
-crashlytics-build.properties
-
+# Gradle
+.gradle/
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,9 @@ bin/
 # IntelliJ
 *.iml
 *.ipr
+*.iws
 .idea/
+out/
 
 # Gradle
 .gradle/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,118 @@
-.classpath
-.project
-.settings/
-.gradle/
+# Created by https://www.gitignore.io/api/java,gradle,eclipse,intellij
+
+### Java ###
+*.class
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+
+### Gradle ###
+.gradle
 build/
 
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+
+### Eclipse ###
+*.pydevproject
+.metadata
+.gradle
 bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+
+# Eclipse Core
+.project
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# CDT-specific
+.cproject
+
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# TeXlipse plugin
+.texlipse
+
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+

--- a/xtext-android-gradle-plugin/src/main/java/org/xtext/gradle/android/XtextAndroidBuilderPlugin.xtend
+++ b/xtext-android-gradle-plugin/src/main/java/org/xtext/gradle/android/XtextAndroidBuilderPlugin.xtend
@@ -16,7 +16,6 @@ import org.xtext.gradle.XtextBuilderPlugin
 import org.xtext.gradle.tasks.Outlet
 import org.xtext.gradle.tasks.XtextExtension
 import org.xtext.gradle.tasks.XtextGenerate
-import org.xtext.gradle.tasks.XtextSourceSetOutputs
 
 class XtextAndroidBuilderPlugin implements Plugin<Project> {
 
@@ -91,10 +90,11 @@ class XtextAndroidBuilderPlugin implements Plugin<Project> {
 						} else {
 							CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, outlet.name)
 						}
-					val output = sourceSet.output as XtextSourceSetOutputs
+					val output = sourceSet.output
 					output.dir(outlet, '''«project.buildDir»/generated/source/«outletFragment»/«sourceSet.name»''')
 				]
 			]
 		]
 	}
+
 }

--- a/xtext-gradle-builder/src/main/java/org/xtext/gradle/builder/AlternateJdkLoader.xtend
+++ b/xtext-gradle-builder/src/main/java/org/xtext/gradle/builder/AlternateJdkLoader.xtend
@@ -11,7 +11,7 @@ class AlternateJdkLoader extends URLClassLoader {
 	private final ConcurrentMap<String, Object> locks = Maps.newConcurrentMap;
 
 	new(Iterable<File> files) {
-		super(files.map[toURL])
+		super(files.map[toURI.toURL])
 	}
 
 	override protected loadClass(String name, boolean resolve) throws ClassNotFoundException {

--- a/xtext-gradle-builder/src/main/java/org/xtext/gradle/builder/XtextGradleBuilder.xtend
+++ b/xtext-gradle-builder/src/main/java/org/xtext/gradle/builder/XtextGradleBuilder.xtend
@@ -110,7 +110,7 @@ class XtextGradleBuilder {
 	}
 	
 	def getJvmTypesLoader(GradleBuildRequest gradleRequest) {
-		val parent = if (gradleRequest.bootClasspath == null) {
+		val parent = if (gradleRequest.bootClasspath === null) {
 			ClassLoader.systemClassLoader
 		} else {
 			new AlternateJdkLoader(gradleRequest.bootClasspath.split(File.pathSeparator).map[new File(it)])

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/GradleBuildTester.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/GradleBuildTester.xtend
@@ -117,7 +117,7 @@ class GradleBuildTester extends ExternalResource {
 		}
 
 		def String getPath() {
-			if (parent == null) {
+			if (parent === null) {
 				""
 			} else {
 				parent.path + ":" + name

--- a/xtext-gradle-plugin/src/main/java/org/xtext/gradle/GradleExtensions.xtend
+++ b/xtext-gradle-plugin/src/main/java/org/xtext/gradle/GradleExtensions.xtend
@@ -1,11 +1,9 @@
 package org.xtext.gradle
 
-import java.util.concurrent.Callable
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1
-import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.dsl.DependencyHandler
-import org.gradle.api.Task
 import org.gradle.api.execution.TaskExecutionAdapter
 
 class GradleExtensions {
@@ -25,4 +23,5 @@ class GradleExtensions {
 			}
 		})
 	}
+
 }

--- a/xtext-gradle-plugin/src/main/java/org/xtext/gradle/XtendLanguageBasePlugin.xtend
+++ b/xtext-gradle-plugin/src/main/java/org/xtext/gradle/XtendLanguageBasePlugin.xtend
@@ -39,7 +39,7 @@ class XtendLanguageBasePlugin implements Plugin<Project> {
 			val builderClasspathBefore = generatorTask.xtextClasspath
 			val classpath = generatorTask.classpath
 			val version = xtext.getXtextVersion(classpath) ?: xtext.getXtextVersion(builderClasspathBefore)
-			if (version == null) {
+			if (version === null) {
 				throw new GradleException('''Could not infer Xtend classpath, because xtext.version was not set and no Xtend libraries were found on the «classpath» classpath''')
 			}
 			val dependencies = #[

--- a/xtext-gradle-plugin/src/main/java/org/xtext/gradle/XtextBuilderPlugin.xtend
+++ b/xtext-gradle-plugin/src/main/java/org/xtext/gradle/XtextBuilderPlugin.xtend
@@ -66,7 +66,7 @@ class XtextBuilderPlugin implements Plugin<Project> {
 			val builderClasspathBefore = generatorTask.xtextClasspath
 			val classpath = generatorTask.classpath
 			val version = xtext.getXtextVersion(classpath) ?: xtext.getXtextVersion(builderClasspathBefore)
-			if (version == null) {
+			if (version === null) {
 				throw new GradleException('''Could not infer Xtext classpath, because xtext.version was not set and no xtext libraries were found on the «classpath» classpath''')
 			}
 			val dependencies = #[

--- a/xtext-gradle-plugin/src/main/java/org/xtext/gradle/tasks/XtextEclipseSettings.xtend
+++ b/xtext-gradle-plugin/src/main/java/org/xtext/gradle/tasks/XtextEclipseSettings.xtend
@@ -37,7 +37,7 @@ class XtextEclipseSettings extends DefaultTask {
 			prefs.putBoolean("generateSuppressWarnings", suppressWarningsAnnotation)
 			prefs.putBoolean("generateGeneratedAnnotation", generatedAnnotation.active)
 			prefs.putBoolean("includeDateInGenerated", generatedAnnotation.includeDate)
-			if (generatedAnnotation.comment != null) {
+			if (generatedAnnotation.comment !== null) {
 				prefs.put("generatedAnnotationComment", generatedAnnotation.comment)
 			}
 			prefs.put("targetJavaVersion", "Java" + JavaVersion.toVersion(javaSourceLevel).majorVersion)

--- a/xtext-gradle-plugin/src/main/java/org/xtext/gradle/tasks/XtextExtension.xtend
+++ b/xtext-gradle-plugin/src/main/java/org/xtext/gradle/tasks/XtextExtension.xtend
@@ -42,7 +42,7 @@ class XtextExtension {
 	static val LIB_PATTERN = Pattern.compile("org\\.eclipse\\.xtext\\..*-(\\d.*?).jar")
 	
 	def String getXtextVersion(FileCollection classpath) {
-		if (version != null)
+		if (version !== null)
 			return version
 		for (file : classpath) {
 			val matcher = LIB_PATTERN.matcher(file.name)

--- a/xtext-gradle-plugin/src/main/java/org/xtext/gradle/tasks/XtextGenerate.xtend
+++ b/xtext-gradle-plugin/src/main/java/org/xtext/gradle/tasks/XtextGenerate.xtend
@@ -151,7 +151,7 @@ class XtextGenerate extends DefaultTask {
 	}
 	
 	private def initializeBuilder() {
-		if (builder != null) {
+		if (builder !== null) {
 			(builder.class.classLoader as URLClassLoader).close
 		}
 		val builderClass = builderClassLoader.loadClass("org.xtext.gradle.builder.XtextGradleBuilder")
@@ -193,6 +193,6 @@ class XtextGenerate extends DefaultTask {
 	
 	private def getBuilderClassLoader() {
 		//TODO parent filtering, we don't want asm etc.
-		new URLClassLoader(xtextClasspath.map[toURL], class.classLoader)
+		new URLClassLoader(xtextClasspath.map[toURI.toURL], class.classLoader)
 	}
 }

--- a/xtext-gradle-plugin/src/main/java/org/xtext/gradle/tasks/internal/DefaultXtextSourceSetOutputs.xtend
+++ b/xtext-gradle-plugin/src/main/java/org/xtext/gradle/tasks/internal/DefaultXtextSourceSetOutputs.xtend
@@ -31,7 +31,7 @@ class DefaultXtextSourceSetOutputs implements XtextSourceSetOutputs {
 	
 	def propertyMissing(String name, Object value) {
 		val outlet = outletsByPropertyName.get(name)
-		if (outlet == null)
+		if (outlet === null)
 			throw new MissingPropertyException('''
 				Unknown output directory '«name»'
 				Known directories are:

--- a/xtext-gradle-protocol/src/main/java/org/xtext/gradle/protocol/IssueSeverity.java
+++ b/xtext-gradle-protocol/src/main/java/org/xtext/gradle/protocol/IssueSeverity.java
@@ -1,12 +1,15 @@
 package org.xtext.gradle.protocol;
 
 public enum IssueSeverity {
+
 	ERROR,
 	WARNING,
 	INFO,
 	IGNORE;
 	
+	@Override
 	public String toString() {
 		return name().toLowerCase();
-	};
+	}
+
 }


### PR DESCRIPTION
When checking out the source code and importing it into Eclipse I get several warnings and artifacts that are not considered in the .gitignore.

The commits eliminate all warnings except for two (in DefaultXtextSourceDirectorySet which are caused by the Gradle API) and replaces the .gitignore by a generated one.