### PR TITLE
Add unit tests for xtext-gradle-plugin

### DIFF
--- a/xtext-gradle-plugin/src/test/java/org/xtext/gradle/AbstractPluginTest.xtend
+++ b/xtext-gradle-plugin/src/test/java/org/xtext/gradle/AbstractPluginTest.xtend
@@ -8,7 +8,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import org.gradle.api.Task
 
 /**
  * Abstract base class for all plugin unit tests.
@@ -42,10 +41,6 @@ abstract class AbstractPluginTest {
 
 	protected def void apply(Project project, Class<? extends Plugin<?>> pluginClass) {
 		project.apply[plugin(pluginClass)]
-	}
-
-	protected def void task(Project project, Class<? extends Task> taskClass, String taskName) {
-		project.task(#{'type' -> taskClass}, taskName)
 	}
 
 	@Test

--- a/xtext-gradle-plugin/src/test/java/org/xtext/gradle/AbstractPluginTest.xtend
+++ b/xtext-gradle-plugin/src/test/java/org/xtext/gradle/AbstractPluginTest.xtend
@@ -43,35 +43,26 @@ abstract class AbstractPluginTest {
 	protected def void apply(Project project, Class<? extends Plugin<?>> pluginClass) {
 		project.apply[plugin(pluginClass)]
 	}
-	
+
 	protected def void task(Project project, Class<? extends Task> taskClass, String taskName) {
-		project.task(#{'type' -> taskClass}, taskName)	
+		project.task(#{'type' -> taskClass}, taskName)
 	}
 
-	/**
-	 * No exception is thrown if plugin is applied to a project.
-	 */
 	@Test
-	def void noExceptionOnApply() {
+	def void shouldNotThrowExceptionIfApplied() {
 		// when
 		project.apply(pluginClass)
 	}
 
-	/**
-	 * No exception is thrown if plugin is applied twice to a project.
-	 */
 	@Test
-	def void applyIsIdempotent() {
+	def void shouldNotThrowExceptionIfAppliedTwice() {
 		// when
 		project.apply(pluginClass)
 		project.apply(pluginClass)
 	}
 
-	/**
-	 * No expection is thrown if plugin is applied to a subproject.
-	 */
 	@Test
-	def void applyOnSingleSubproject() {
+	def void canBeAppliedOnSubproject() {
 		// given
 		val subproject = project.createSubproject('subproject')
 
@@ -79,12 +70,8 @@ abstract class AbstractPluginTest {
 		subproject.apply(pluginClass)
 	}
 
-	/**
-	 * No exception is thrown if plugin is applied to the root project and multiple
-	 * subprojects.
-	 */
 	@Test
-	def void applyOnRootAndMultipleSubprojects() {
+	def void canBeAppliedOnRootAndMultipleSubprojects() {
 		// given
 		val subprojects = #['a', 'b', 'c'].map[project.createSubproject(it)]
 

--- a/xtext-gradle-plugin/src/test/java/org/xtext/gradle/AbstractPluginTest.xtend
+++ b/xtext-gradle-plugin/src/test/java/org/xtext/gradle/AbstractPluginTest.xtend
@@ -1,0 +1,96 @@
+package org.xtext.gradle
+
+import java.io.File
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.gradle.api.Task
+
+/**
+ * Abstract base class for all plugin unit tests.
+ * Contains some basic tests that every plugin should suffice.
+ */
+abstract class AbstractPluginTest {
+
+	@Rule public val temporaryFolder = new TemporaryFolder()
+
+	protected Project project
+	protected File projectDir
+
+	abstract def Class<? extends Plugin<?>> getPluginClass()
+
+	/** 
+	 * Setup the root project.
+	 */
+	@Before
+	def void setupProject() {
+		projectDir = temporaryFolder.root
+		project = ProjectBuilder.builder.withProjectDir(projectDir).build
+	}
+
+	/**
+	 * Helper method for creating new subprojects.
+	 */
+	protected def Project createSubproject(Project parentProject, String name) {
+		return ProjectBuilder.builder.withName(name).withProjectDir(new File(projectDir, name)).withParent(
+			parentProject).build
+	}
+
+	protected def void apply(Project project, Class<? extends Plugin<?>> pluginClass) {
+		project.apply[plugin(pluginClass)]
+	}
+	
+	protected def void task(Project project, Class<? extends Task> taskClass, String taskName) {
+		project.task(#{'type' -> taskClass}, taskName)	
+	}
+
+	/**
+	 * No exception is thrown if plugin is applied to a project.
+	 */
+	@Test
+	def void noExceptionOnApply() {
+		// when
+		project.apply(pluginClass)
+	}
+
+	/**
+	 * No exception is thrown if plugin is applied twice to a project.
+	 */
+	@Test
+	def void applyIsIdempotent() {
+		// when
+		project.apply(pluginClass)
+		project.apply(pluginClass)
+	}
+
+	/**
+	 * No expection is thrown if plugin is applied to a subproject.
+	 */
+	@Test
+	def void applyOnSingleSubproject() {
+		// given
+		val subproject = project.createSubproject('subproject')
+
+		// when
+		subproject.apply(pluginClass)
+	}
+
+	/**
+	 * No exception is thrown if plugin is applied to the root project and multiple
+	 * subprojects.
+	 */
+	@Test
+	def void applyOnRootAndMultipleSubprojects() {
+		// given
+		val subprojects = #['a', 'b', 'c'].map[project.createSubproject(it)]
+
+		// when
+		project.apply(pluginClass)
+		subprojects.forEach[apply(pluginClass)]
+	}
+
+}

--- a/xtext-gradle-plugin/src/test/java/org/xtext/gradle/XtendLanguageBasePluginTest.xtend
+++ b/xtext-gradle-plugin/src/test/java/org/xtext/gradle/XtendLanguageBasePluginTest.xtend
@@ -1,0 +1,37 @@
+package org.xtext.gradle
+
+import org.gradle.api.plugins.JavaBasePlugin
+import org.junit.Test
+import org.xtext.gradle.tasks.XtextExtension
+
+import static org.junit.Assert.*
+
+class XtendLanguageBasePluginTest extends AbstractPluginTest {
+
+	override getPluginClass() {
+		XtendLanguageBasePlugin
+	}
+
+	@Test
+	def void expectedPluginsAreAdded() {
+		// when
+		project.apply(pluginClass)
+
+		// then
+		assertTrue(project.plugins.hasPlugin(JavaBasePlugin))
+		assertTrue(project.plugins.hasPlugin(XtextBuilderPlugin))
+		assertTrue(project.plugins.hasPlugin(XtextJavaLanguagePlugin))
+	}
+
+	@Test
+	def void xtendLanguageIsAdded() {
+		// when
+		project.apply(pluginClass)
+
+		// then
+		val ext = project.extensions.getByType(XtextExtension)
+		val languageNames = ext.languages.names
+		assertTrue(languageNames.contains('xtend'))
+	}
+
+}

--- a/xtext-gradle-plugin/src/test/java/org/xtext/gradle/XtendLanguagePluginTest.xtend
+++ b/xtext-gradle-plugin/src/test/java/org/xtext/gradle/XtendLanguagePluginTest.xtend
@@ -1,0 +1,36 @@
+package org.xtext.gradle
+
+import org.gradle.api.plugins.JavaPlugin
+import org.junit.Test
+import org.xtext.gradle.tasks.XtextGenerate
+
+import static org.junit.Assert.*
+
+class XtendLanguagePluginTest extends AbstractPluginTest {
+
+	override getPluginClass() {
+		XtendLanguagePlugin
+	}
+
+	@Test
+	def void expectedPluginsAreAdded() {
+		// when
+		project.apply(pluginClass)
+
+		// then
+		assertTrue(project.plugins.hasPlugin(JavaPlugin))
+		assertTrue(project.plugins.hasPlugin(XtendLanguageBasePlugin))
+	}
+	
+	@Test
+	def void generateXtextTasksAreAvailable() {
+		// when
+		project.apply(pluginClass)
+		
+		// then
+		val taskNames = project.tasks.withType(XtextGenerate).names
+		assertTrue(taskNames.contains('generateXtext'))
+		assertTrue(taskNames.contains('generateTestXtext'))
+	}
+
+}

--- a/xtext-gradle-plugin/src/test/java/org/xtext/gradle/XtextBuilderPluginTest.xtend
+++ b/xtext-gradle-plugin/src/test/java/org/xtext/gradle/XtextBuilderPluginTest.xtend
@@ -1,0 +1,59 @@
+package org.xtext.gradle
+
+import org.gradle.api.plugins.JavaBasePlugin
+import org.gradle.api.plugins.JavaPluginConvention
+import org.junit.Test
+import org.xtext.gradle.tasks.XtextExtension
+import org.xtext.gradle.tasks.XtextGenerate
+
+import static org.junit.Assert.*
+
+class XtextBuilderPluginTest extends AbstractPluginTest {
+
+	override getPluginClass() {
+		XtextBuilderPlugin
+	}
+
+	@Test
+	def void xtextExtensionIsAdded() {
+		// when
+		project.apply(pluginClass)
+
+		// then	
+		assertNotNull(project.extensions.getByType(XtextExtension))
+	}
+
+	@Test
+	def void xtextToolingConfigurationIsAdded() {
+		// when
+		project.apply(pluginClass)
+
+		// then
+		assertNotNull(project.configurations.getByName('xtextTooling'))
+	}
+
+	/**
+	 * A task should be added for every Java source set.
+	 */
+	@Test
+	def void generateXtextTaskIsAddedForAllSourceSets() {
+		// given
+		project.apply(JavaBasePlugin)
+		val java = project.convention.findPlugin(JavaPluginConvention)
+		java.sourceSets => [
+			create('main')
+			create('custom')
+			create('test')
+		]
+
+		// when
+		project.apply(pluginClass)
+
+		// then
+		val taskNames = project.tasks.withType(XtextGenerate).names
+		assertTrue(taskNames.contains('generateXtext'))
+		assertTrue(taskNames.contains('generateCustomXtext'))
+		assertTrue(taskNames.contains('generateTestXtext'))
+	}
+
+}

--- a/xtext-gradle-plugin/src/test/java/org/xtext/gradle/XtextBuilderPluginTest.xtend
+++ b/xtext-gradle-plugin/src/test/java/org/xtext/gradle/XtextBuilderPluginTest.xtend
@@ -32,11 +32,8 @@ class XtextBuilderPluginTest extends AbstractPluginTest {
 		assertNotNull(project.configurations.getByName('xtextTooling'))
 	}
 
-	/**
-	 * A task should be added for every Java source set.
-	 */
 	@Test
-	def void generateXtextTaskIsAddedForAllSourceSets() {
+	def void generateXtextTaskIsAddedForEverySourceSet() {
 		// given
 		project.apply(JavaBasePlugin)
 		val java = project.convention.findPlugin(JavaPluginConvention)

--- a/xtext-gradle-plugin/src/test/java/org/xtext/gradle/XtextJavaLanguagePluginTest.xtend
+++ b/xtext-gradle-plugin/src/test/java/org/xtext/gradle/XtextJavaLanguagePluginTest.xtend
@@ -1,0 +1,34 @@
+package org.xtext.gradle
+
+import org.junit.Test
+import org.xtext.gradle.tasks.XtextExtension
+
+import static org.junit.Assert.*
+
+class XtextJavaLanguagePluginTest extends AbstractPluginTest {
+
+	override getPluginClass() {
+		XtextJavaLanguagePlugin
+	}
+
+	@Test
+	def void expectedPluginsAreAdded() {
+		// when
+		project.apply(pluginClass)
+
+		// then
+		assertTrue(project.plugins.hasPlugin(XtextBuilderPlugin))
+	}
+
+	@Test
+	def void javaLanguageIsAdded() {
+		// when
+		project.apply(pluginClass)
+
+		// then
+		val ext = project.extensions.getByType(XtextExtension)
+		val languageNames = ext.languages.names
+		assertTrue(languageNames.contains('java'))
+	}
+
+}


### PR DESCRIPTION
I wrote a couple of unit tests for the plugins added by `xtext-gradle-plugin`.
They verify some basic behavior, e.g. that they can be applied without exception and so on.

What do you think?