### PR TITLE
Cleanup and improve integration tests

### DIFF
--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/AbstractIntegrationTest.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/AbstractIntegrationTest.xtend
@@ -1,5 +1,7 @@
 package org.xtext.gradle.test
 
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.BuildTask
 import org.junit.Before
 import org.junit.Rule
 import org.xtext.gradle.test.GradleBuildTester.ProjectUnderTest
@@ -36,5 +38,14 @@ class AbstractIntegrationTest {
 			jcenter()
 		}
 	'''
+	
+	def BuildTask getXtextTask(BuildResult buildResult) {
+		buildResult.getXtextTask(rootProject)
+	}
+	
+	def BuildTask getXtextTask(BuildResult buildResult, ProjectUnderTest project) {
+		val taskName = '''«project.path»:generateXtext'''
+		return buildResult.task(taskName)
+	}
 
 }

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/AbstractIntegrationTest.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/AbstractIntegrationTest.xtend
@@ -1,0 +1,40 @@
+package org.xtext.gradle.test
+
+import org.junit.Before
+import org.junit.Rule
+import org.xtext.gradle.test.GradleBuildTester.ProjectUnderTest
+
+class AbstractIntegrationTest {
+
+	@Rule public extension GradleBuildTester tester = new GradleBuildTester
+	protected extension ProjectUnderTest rootProject
+	protected val extension XtextBuilderAssertions = new XtextBuilderAssertions
+
+	@Before
+	def void setup() {
+		rootProject = tester.rootProject
+		buildFile = '''
+			buildscript {
+				«repositories»
+				dependencies {
+					classpath 'org.xtext:xtext-gradle-plugin:«System.getProperty("gradle.project.version") ?: 'unspecified'»'
+				}
+			}
+			
+			allprojects {
+				«repositories»
+			}
+		'''
+	}
+	
+	protected def CharSequence getRepositories() '''
+		repositories {
+			mavenLocal()
+			maven {
+				url 'https://oss.sonatype.org/content/repositories/snapshots'
+			}
+			jcenter()
+		}
+	'''
+
+}

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingAMultiModuleXtendProject.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingAMultiModuleXtendProject.xtend
@@ -1,47 +1,24 @@
 package org.xtext.gradle.test
 
-import org.junit.Test
-import org.junit.Rule
-import org.junit.Before
-import org.xtext.gradle.test.GradleBuildTester.ProjectUnderTest
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Test
+import org.xtext.gradle.test.GradleBuildTester.ProjectUnderTest
+
 import static org.junit.Assert.*
 
-class BuildingAMultiModuleXtendProject {
-	@Rule public extension GradleBuildTester tester = new GradleBuildTester
-	val extension XtextBuilderAssertions = new XtextBuilderAssertions
+class BuildingAMultiModuleXtendProject extends AbstractIntegrationTest {
+	
 	ProjectUnderTest upStreamProject
 	ProjectUnderTest downStreamProject
 	
-	@Before
-	def void setup() {
+	override setup() {
+		super.setup
 		upStreamProject = rootProject.createSubProject("upStream")
 		downStreamProject = rootProject.createSubProject("downStream")
-		rootProject.buildFile = '''
-			buildscript {
-				repositories {
-					mavenLocal()
-					maven {
-						url 'https://oss.sonatype.org/content/repositories/snapshots'
-					}
-					jcenter()
-				}
-				dependencies {
-					classpath 'org.xtext:xtext-gradle-plugin:«System.getProperty("gradle.project.version") ?: 'unspecified'»'
-				}
-			}
-			
+		rootProject.buildFile << '''
 			subprojects {
 				apply plugin: 'org.xtext.xtend'
-
-				repositories {
-					mavenLocal()
-					maven {
-						url 'https://oss.sonatype.org/content/repositories/snapshots'
-					}
-					jcenter()
-				}
-
+				
 				dependencies {
 					compile 'org.eclipse.xtend:org.eclipse.xtend.lib:2.9.0-SNAPSHOT'
 				}

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingAMultiModuleXtendProject.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingAMultiModuleXtendProject.xtend
@@ -1,10 +1,7 @@
 package org.xtext.gradle.test
 
-import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Test
 import org.xtext.gradle.test.GradleBuildTester.ProjectUnderTest
-
-import static org.junit.Assert.*
 
 class BuildingAMultiModuleXtendProject extends AbstractIntegrationTest {
 	
@@ -48,7 +45,7 @@ class BuildingAMultiModuleXtendProject extends AbstractIntegrationTest {
 			{}
 		'''
 		val secondResult = build("build")
-		assertEquals(TaskOutcome.UP_TO_DATE, secondResult.task(":downStream:generateXtext").outcome)
+		secondResult.getXtextTask(downStreamProject).shouldBeUpToDate
 	}
 	
 	@Test
@@ -63,4 +60,5 @@ class BuildingAMultiModuleXtendProject extends AbstractIntegrationTest {
 		val result = build("build", "-i")
 		result.hasRunGeneratorFor(downStream)
 	}
+
 }

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingAPlainLanguageProject.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingAPlainLanguageProject.xtend
@@ -1,9 +1,6 @@
 package org.xtext.gradle.test
 
-import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Test
-
-import static org.junit.Assert.*
 
 //TODO use a different language than Xtend
 class BuildingAPlainLanguageProject extends AbstractIntegrationTest {
@@ -60,7 +57,7 @@ class BuildingAPlainLanguageProject extends AbstractIntegrationTest {
 
 		build("generateXtext")
 		val secondResult = build("generateXtext")
-		assertEquals(TaskOutcome.UP_TO_DATE, secondResult.task(":generateXtext").outcome)
+		secondResult.xtextTask.shouldBeUpToDate
 	}
 
 	@Test

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingAPlainLanguageProject.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingAPlainLanguageProject.xtend
@@ -1,44 +1,17 @@
 package org.xtext.gradle.test
 
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.xtext.gradle.test.GradleBuildTester.ProjectUnderTest
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Test
+
 import static org.junit.Assert.*
 
 //TODO use a different language than Xtend
-class BuildingAPlainLanguageProject {
-	@Rule public extension GradleBuildTester tester = new GradleBuildTester
-	val extension XtextBuilderAssertions = new XtextBuilderAssertions
-	extension ProjectUnderTest rootProject
+class BuildingAPlainLanguageProject extends AbstractIntegrationTest {
 
-	@Before
-	def void setup() {
-		rootProject = tester.rootProject
-		buildFile = '''
-			buildscript {
-				repositories {
-					mavenLocal()
-					maven {
-						url 'https://oss.sonatype.org/content/repositories/snapshots'
-					}
-					jcenter()
-				}
-				dependencies {
-					classpath 'org.xtext:xtext-gradle-plugin:«System.getProperty("gradle.project.version") ?: 'unspecified'»'
-				}
-			}
-			
+	override setup() {
+		super.setup
+		buildFile << '''
 			apply plugin: 'org.xtext.builder'
-			
-			repositories {
-				mavenLocal()
-				maven {
-					url 'https://oss.sonatype.org/content/repositories/snapshots'
-				}
-				jcenter()
-			}
 			
 			configurations {
 				compile

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingASimpleXtendProject.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingASimpleXtendProject.xtend
@@ -1,44 +1,16 @@
 package org.xtext.gradle.test
 
 import org.gradle.testkit.runner.TaskOutcome
-import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.xtext.gradle.test.GradleBuildTester.ProjectUnderTest
 
 import static org.junit.Assert.*
 
-class BuildingASimpleXtendProject {
-	@Rule public extension GradleBuildTester tester = new GradleBuildTester
-	val extension XtextBuilderAssertions = new XtextBuilderAssertions
-	extension ProjectUnderTest rootProject
+class BuildingASimpleXtendProject extends AbstractIntegrationTest {
 
-	@Before
-	def void setup() {
-		rootProject = tester.rootProject
-		buildFile = '''
-			buildscript {
-				repositories {
-					mavenLocal()
-					maven {
-						url 'https://oss.sonatype.org/content/repositories/snapshots'
-					}
-					jcenter()
-				}
-				dependencies {
-					classpath 'org.xtext:xtext-gradle-plugin:«System.getProperty("gradle.project.version") ?: 'unspecified'»'
-				}
-			}
-			
+	override setup() {
+		super.setup
+		buildFile << '''
 			apply plugin: 'org.xtext.xtend'
-			
-			repositories {
-				mavenLocal()
-				maven {
-					url 'https://oss.sonatype.org/content/repositories/snapshots'
-				}
-				jcenter()
-			}
 			
 			dependencies {
 				compile 'org.eclipse.xtend:org.eclipse.xtend.lib:2.9.0-SNAPSHOT'

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingASimpleXtendProject.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingASimpleXtendProject.xtend
@@ -1,9 +1,6 @@
 package org.xtext.gradle.test
 
-import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Test
-
-import static org.junit.Assert.*
 
 class BuildingASimpleXtendProject extends AbstractIntegrationTest {
 
@@ -38,7 +35,7 @@ class BuildingASimpleXtendProject extends AbstractIntegrationTest {
 
 		build("build")
 		val secondResult = build("build")
-		assertEquals(TaskOutcome.UP_TO_DATE, secondResult.task(":generateXtext").outcome)
+		secondResult.xtextTask.shouldBeUpToDate
 	}
 
 	@Test

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/GradleBuildTester.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/GradleBuildTester.xtend
@@ -58,6 +58,10 @@ class GradleBuildTester extends ExternalResource {
 		}
 	}
 
+	def void << (File file, CharSequence content) {
+		file.append(content)
+	}
+
 	def String getContentAsString(File file) {
 		Files.toString(file, Charsets.UTF_8)
 	}
@@ -89,6 +93,10 @@ class GradleBuildTester extends ExternalResource {
 
 		def void setBuildFile(CharSequence content) {
 			new File(projectDir, 'build.gradle').content = content
+		}
+
+		def File getBuildFile() {
+			new File(projectDir, 'build.gradle')
 		}
 
 		def File file(String relativePath) {

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/GradleBuildTester.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/GradleBuildTester.xtend
@@ -7,7 +7,9 @@ import java.util.Collections
 import java.util.Set
 import org.eclipse.xtend.lib.annotations.Accessors
 import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.BuildTask
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
 import org.junit.rules.ExternalResource
 import org.junit.rules.TemporaryFolder
 
@@ -86,6 +88,18 @@ class GradleBuildTester extends ExternalResource {
 
 	def void shouldContain(File file, CharSequence content) {
 		assertEquals(content.toString, file.contentAsString)
+	}
+	
+	def void shouldBeUpToDate(BuildTask task) {
+		if (task.outcome != TaskOutcome.UP_TO_DATE) {
+			fail('''Expected task '«task.path»' to be <UP-TO-DATE> but was: <«task.outcome»>''')			
+		}
+	}
+	
+	def void shouldNotBeUpToDate(BuildTask task) {
+		if (task.outcome == TaskOutcome.UP_TO_DATE) {
+			fail('''Expected task '«task.path»' not to be <UP-TO-DATE> but it was.''')
+		}
 	}
 
 	private def addSubProjectToBuild(ProjectUnderTest project) {

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/GradleBuildTester.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/GradleBuildTester.xtend
@@ -71,7 +71,17 @@ class GradleBuildTester extends ExternalResource {
 	}
 
 	def void shouldExist(File file) {
-		assertTrue(file.exists)
+		if (!file.exists) {
+			val relativePath = rootProject.projectDir.toPath.relativize(file.toPath)
+			fail('''File '«relativePath»' should exist but it does not.''')
+		}
+	}
+	
+	def void shouldNotExist(File file) {
+		if (file.exists) {
+			val relativePath = rootProject.projectDir.toPath.relativize(file.toPath)
+			fail('''File '«relativePath»' should not exist but it does.''')
+		}
 	}
 
 	def void shouldContain(File file, CharSequence content) {

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/WhenConfiguringTheDebuggerSupport.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/WhenConfiguringTheDebuggerSupport.xtend
@@ -1,25 +1,15 @@
 package org.xtext.gradle.test
 
-import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.Opcodes
 import org.xtext.gradle.protocol.GradleInstallDebugInfoRequest.SourceInstaller
-import org.xtext.gradle.test.GradleBuildTester.ProjectUnderTest
 
 import static org.junit.Assert.*
 
-class WhenConfiguringTheDebuggerSupport {
-	@Rule public extension GradleBuildTester tester = new GradleBuildTester
-	extension ProjectUnderTest rootProject
+class WhenConfiguringTheDebuggerSupport extends AbstractIntegrationTest {
 
-	@Before
-	def void setup() {
-		rootProject = tester.rootProject
-	}
-	
 	@Test
 	def void sourcesCanBeInstalledAsSmap() {
 		testSourceInstallation(SourceInstaller.SMAP)[name, info|
@@ -44,31 +34,10 @@ class WhenConfiguringTheDebuggerSupport {
 	}
 	
 	private def testSourceInstallation(SourceInstaller sourceInstaller, (String, String) => void sourceVisitor) {
-		buildFile = '''
-			buildscript {
-				repositories {
-					mavenLocal()
-					maven {
-						url 'https://oss.sonatype.org/content/repositories/snapshots'
-					}
-					jcenter()
-				}
-				dependencies {
-					classpath 'org.xtext:xtext-gradle-plugin:«System.getProperty("gradle.project.version") ?: 'unspecified'»'
-				}
-			}
-			
+		buildFile << '''
 			apply plugin: 'java'
 			apply plugin: 'org.xtext.builder'
 			apply plugin: 'org.xtext.java'
-			
-			repositories {
-				mavenLocal()
-				maven {
-					url 'https://oss.sonatype.org/content/repositories/snapshots'
-				}
-				jcenter()
-			}
 			
 			dependencies {
 				compile 'org.eclipse.xtend:org.eclipse.xtend.lib:2.9.0-SNAPSHOT'

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/WhenTheEclipsePluginIsApplied.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/WhenTheEclipsePluginIsApplied.xtend
@@ -1,35 +1,16 @@
 package org.xtext.gradle.test
 
 import org.eclipse.core.internal.preferences.EclipsePreferences
-import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.xtext.gradle.tasks.internal.XtextEclipsePreferences
-import org.xtext.gradle.test.GradleBuildTester.ProjectUnderTest
 
 import static org.junit.Assert.*
 
-class WhenTheEclipsePluginIsApplied {
-	@Rule public extension GradleBuildTester tester = new GradleBuildTester
-	extension ProjectUnderTest rootProject
+class WhenTheEclipsePluginIsApplied extends AbstractIntegrationTest {
 
-	@Before
-	def void setup() {
-		rootProject = tester.rootProject
-		buildFile = '''
-			buildscript {
-				repositories {
-					mavenLocal()
-					maven {
-						url 'https://oss.sonatype.org/content/repositories/snapshots'
-					}
-					jcenter()
-				}
-				dependencies {
-					classpath 'org.xtext:xtext-gradle-plugin:«System.getProperty("gradle.project.version") ?: 'unspecified'»'
-				}
-			}
-			
+	override setup() {
+		super.setup
+		buildFile << '''
 			apply plugin: 'java'
 			apply plugin: 'eclipse'
 			apply plugin: 'org.xtext.builder'
@@ -63,7 +44,7 @@ class WhenTheEclipsePluginIsApplied {
 		build("eclipse")
 		val prefs = new XtextEclipsePreferences(projectDir, "org.eclipse.xtend.core.Xtend")
 		prefs.load
-		
+
 		prefs.shouldContain("BuilderConfiguration.is_project_specific", true)
 		prefs.shouldContain("ValidatorConfiguration.is_project_specific", true)
 		prefs.shouldContain("generateSuppressWarnings", true)
@@ -76,11 +57,11 @@ class WhenTheEclipsePluginIsApplied {
 		prefs.shouldContain("outlet.DEFAULT_OUTPUT.hideLocalSyntheticVariables", true)
 		prefs.shouldContain("outlet.DEFAULT_OUTPUT.sourceFolder.src/main/java.directory", "build/xtend/main")
 		prefs.shouldContain("outlet.DEFAULT_OUTPUT.sourceFolder.src/test/java.directory", "build/xtend/test")
-		
+
 		prefs.shouldContain("org.eclipse.xtend.some.some.issue", "error")
 		prefs.shouldContain("org.eclipse.xtend.some.pref", "true")
 	}
-	
+
 	def shouldContain(EclipsePreferences prefs, String key, Object value) {
 		assertEquals(value.toString, prefs.get(key, null))
 	}


### PR DESCRIPTION
This change introduces an abstract class for integration tests in `xtext-gradle-plugin` and lets the tests inherit from it.

Further changes:
* Add a groovy-like syntax for writing into files by overloading the `<<` operator
* Add method `shouldNotExist(File)` and provide better error message for `shouldExist(File)`
* Add helper method for retrieving the `:generateXtext` task
* Add method `shouldBeUpToDate(BuildTask)` and `shouldNotBeUpToDate(BuildTask)` 

