### PR TITLE
Add more integration tests

### DIFF
--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/AbstractIntegrationTest.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/AbstractIntegrationTest.xtend
@@ -1,5 +1,6 @@
 package org.xtext.gradle.test
 
+import java.io.File
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.BuildTask
 import org.junit.Before
@@ -46,6 +47,18 @@ class AbstractIntegrationTest {
 			compile 'org.eclipse.xtend:org.eclipse.xtend.lib:2.9.0-SNAPSHOT'
 		}
 	'''
+	
+	protected def File createXtendHelloWorld() {
+		createFile('src/main/java/HelloWorld.xtend', '''
+			class HelloWorld {
+				
+				def void helloWorld() {
+					#['hello', 'world'].forEach[println(toFirstUpper)]
+				}
+				
+			}
+		''')
+	}
 	
 	def BuildTask getXtextTask(BuildResult buildResult) {
 		buildResult.getXtextTask(rootProject)

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/AbstractIntegrationTest.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/AbstractIntegrationTest.xtend
@@ -39,6 +39,14 @@ class AbstractIntegrationTest {
 		}
 	'''
 	
+	protected def CharSequence getXtendPluginSnippet() '''
+		apply plugin: 'org.xtext.xtend'
+		
+		dependencies {
+			compile 'org.eclipse.xtend:org.eclipse.xtend.lib:2.9.0-SNAPSHOT'
+		}
+	'''
+	
 	def BuildTask getXtextTask(BuildResult buildResult) {
 		buildResult.getXtextTask(rootProject)
 	}

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/AbstractIntegrationTest.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/AbstractIntegrationTest.xtend
@@ -1,13 +1,12 @@
 package org.xtext.gradle.test
 
-import java.io.File
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.BuildTask
 import org.junit.Before
 import org.junit.Rule
 import org.xtext.gradle.test.GradleBuildTester.ProjectUnderTest
 
-class AbstractIntegrationTest {
+abstract class AbstractIntegrationTest {
 
 	@Rule public extension GradleBuildTester tester = new GradleBuildTester
 	protected extension ProjectUnderTest rootProject
@@ -39,26 +38,6 @@ class AbstractIntegrationTest {
 			jcenter()
 		}
 	'''
-	
-	protected def CharSequence getXtendPluginSnippet() '''
-		apply plugin: 'org.xtext.xtend'
-		
-		dependencies {
-			compile 'org.eclipse.xtend:org.eclipse.xtend.lib:2.9.0-SNAPSHOT'
-		}
-	'''
-	
-	protected def File createXtendHelloWorld() {
-		createFile('src/main/java/HelloWorld.xtend', '''
-			class HelloWorld {
-				
-				def void helloWorld() {
-					#['hello', 'world'].forEach[println(toFirstUpper)]
-				}
-				
-			}
-		''')
-	}
 	
 	def BuildTask getXtextTask(BuildResult buildResult) {
 		buildResult.getXtextTask(rootProject)

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/AbstractXtendIntegrationTest.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/AbstractXtendIntegrationTest.xtend
@@ -1,0 +1,36 @@
+package org.xtext.gradle.test
+
+import java.io.File
+
+abstract class AbstractXtendIntegrationTest extends AbstractIntegrationTest {
+	
+	override setup() {
+		super.setup()
+		applyXtendPlugin
+	}
+	
+	protected def void applyXtendPlugin() {
+		buildFile << xtendPluginSnippet
+	}
+	
+	protected def CharSequence getXtendPluginSnippet() '''
+		apply plugin: 'org.xtext.xtend'
+		
+		dependencies {
+			compile 'org.eclipse.xtend:org.eclipse.xtend.lib:2.9.0-SNAPSHOT'
+		}
+	'''
+	
+	protected def File createHelloWorld() {
+		createFile('src/main/java/HelloWorld.xtend', '''
+			class HelloWorld {
+				
+				def void helloWorld() {
+					#['hello', 'world'].forEach[println(toFirstUpper)]
+				}
+				
+			}
+		''')
+	}
+	
+}

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingAMultiModuleXtendProject.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingAMultiModuleXtendProject.xtend
@@ -3,19 +3,24 @@ package org.xtext.gradle.test
 import org.junit.Test
 import org.xtext.gradle.test.GradleBuildTester.ProjectUnderTest
 
-class BuildingAMultiModuleXtendProject extends AbstractIntegrationTest {
+class BuildingAMultiModuleXtendProject extends AbstractXtendIntegrationTest {
 	
 	ProjectUnderTest upStreamProject
 	ProjectUnderTest downStreamProject
+	
+	override protected applyXtendPlugin() {
+		rootProject.buildFile << '''
+			subprojects {
+				«xtendPluginSnippet»
+			}
+		'''
+	}
 	
 	override setup() {
 		super.setup
 		upStreamProject = rootProject.createSubProject("upStream")
 		downStreamProject = rootProject.createSubProject("downStream")
 		rootProject.buildFile << '''
-			subprojects {
-				«xtendPluginSnippet»
-			}
 			project('«downStreamProject.path»').dependencies {
 				compile project('«upStreamProject.path»')
 			}

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingAMultiModuleXtendProject.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingAMultiModuleXtendProject.xtend
@@ -14,11 +14,7 @@ class BuildingAMultiModuleXtendProject extends AbstractIntegrationTest {
 		downStreamProject = rootProject.createSubProject("downStream")
 		rootProject.buildFile << '''
 			subprojects {
-				apply plugin: 'org.xtext.xtend'
-				
-				dependencies {
-					compile 'org.eclipse.xtend:org.eclipse.xtend.lib:2.9.0-SNAPSHOT'
-				}
+				«xtendPluginSnippet»
 			}
 			project('«downStreamProject.path»').dependencies {
 				compile project('«upStreamProject.path»')

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingANonStandardXtendProject.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingANonStandardXtendProject.xtend
@@ -1,11 +1,9 @@
 package org.xtext.gradle.test
 
-import org.junit.Ignore
+import java.util.regex.Pattern
 import org.junit.Test
 
-import static org.hamcrest.core.IsEqual.equalTo
 import static org.junit.Assert.*
-import static org.junit.Assume.*
 
 /**
  * Tests for Xtend projects that do not use the default configuration.
@@ -18,9 +16,7 @@ class BuildingANonStandardXtendProject extends AbstractIntegrationTest {
 	}
 
 	@Test
-	def void compilesToJava8WhenConfigured() {
-		assumeTrue(System.getProperty('java.version').startsWith('1.8'))
-
+	def void compilesToJava8SourceWhenConfigured() {
 		// given 
 		createXtendHelloWorld
 		buildFile << '''
@@ -32,11 +28,12 @@ class BuildingANonStandardXtendProject extends AbstractIntegrationTest {
 
 		// then
 		val generatedJava = file('build/xtend/main/HelloWorld.java').contentAsString
-		assertTrue(generatedJava.contains('import java.util.function.Consumer;'))
+		val lambda = Pattern.compile('''\(String \w+\) -> \{''')
+		assertTrue(lambda.matcher(generatedJava).find)
 	}
 
-	@Test @Ignore
-	def void compilesToJava7WhenConfigured() {
+	@Test
+	def void compilesToJava7SourceWhenConfigured() {
 		// given 
 		createXtendHelloWorld
 		buildFile << '''
@@ -48,7 +45,8 @@ class BuildingANonStandardXtendProject extends AbstractIntegrationTest {
 
 		// then
 		val generatedJava = file('build/xtend/main/HelloWorld.java').contentAsString
-		assertFalse(generatedJava.contains('import java.util.function.Consumer;'))
+		val anonymousInnerClass = Pattern.compile('''new \w*<String>\(\) \{''')
+		assertTrue(anonymousInnerClass.matcher(generatedJava).find)
 	}
 
 	@Test

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingANonStandardXtendProject.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingANonStandardXtendProject.xtend
@@ -8,17 +8,12 @@ import static org.junit.Assert.*
 /**
  * Tests for Xtend projects that do not use the default configuration.
  */
-class BuildingANonStandardXtendProject extends AbstractIntegrationTest {
-
-	override setup() {
-		super.setup()
-		buildFile << xtendPluginSnippet
-	}
+class BuildingANonStandardXtendProject extends AbstractXtendIntegrationTest {
 
 	@Test
 	def void compilesToJava8SourceWhenConfigured() {
 		// given 
-		createXtendHelloWorld
+		createHelloWorld
 		buildFile << '''
 			xtext.languages.xtend.generator.javaSourceLevel = "1.8"
 		'''
@@ -35,7 +30,7 @@ class BuildingANonStandardXtendProject extends AbstractIntegrationTest {
 	@Test
 	def void compilesToJava7SourceWhenConfigured() {
 		// given 
-		createXtendHelloWorld
+		createHelloWorld
 		buildFile << '''
 			xtext.languages.xtend.generator.javaSourceLevel = "1.7"
 		'''

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingANonStandardXtendProject.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingANonStandardXtendProject.xtend
@@ -1,0 +1,80 @@
+package org.xtext.gradle.test
+
+import org.junit.Ignore
+import org.junit.Test
+
+import static org.hamcrest.core.IsEqual.equalTo
+import static org.junit.Assert.*
+import static org.junit.Assume.*
+
+/**
+ * Tests for Xtend projects that do not use the default configuration.
+ */
+class BuildingANonStandardXtendProject extends AbstractIntegrationTest {
+
+	override setup() {
+		super.setup()
+		buildFile << xtendPluginSnippet
+	}
+
+	@Test
+	def void compilesToJava8WhenConfigured() {
+		assumeTrue(System.getProperty('java.version').startsWith('1.8'))
+
+		// given 
+		createXtendHelloWorld
+		buildFile << '''
+			xtext.languages.xtend.generator.javaSourceLevel = "1.8"
+		'''
+
+		// when
+		build('generateXtext')
+
+		// then
+		val generatedJava = file('build/xtend/main/HelloWorld.java').contentAsString
+		assertTrue(generatedJava.contains('import java.util.function.Consumer;'))
+	}
+
+	@Test @Ignore
+	def void compilesToJava7WhenConfigured() {
+		// given 
+		createXtendHelloWorld
+		buildFile << '''
+			xtext.languages.xtend.generator.javaSourceLevel = "1.7"
+		'''
+
+		// when
+		build('generateXtext')
+
+		// then
+		val generatedJava = file('build/xtend/main/HelloWorld.java').contentAsString
+		assertFalse(generatedJava.contains('import java.util.function.Consumer;'))
+	}
+
+	@Test
+	def void failsOnConstantBooleanExpressionWhenConfigured() {
+		// given
+		createFile('src/main/java/HelloWorld.xtend', '''
+			class HelloWorld {
+				
+				def void helloWorld() {
+					if (true) {
+					}
+				}
+				
+			}
+		''')
+		buildFile << '''
+			xtext.languages.xtend.validator {
+				error 'org.eclipse.xtext.xbase.validation.IssueCodes.constant_condition'
+			}
+		'''
+
+		// when
+		val result = buildAndFail('build')
+
+		// then
+		assertTrue(result.standardError.contains('Constant condition is always true'))
+	}
+
+}

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingASimpleXtendProject.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingASimpleXtendProject.xtend
@@ -129,6 +129,35 @@ class BuildingASimpleXtendProject extends AbstractIntegrationTest {
 		'''
 		build('build')
 	}
+	
+	@Test
+	def void classFilesAreGenerated() {
+		// given
+		file('src/main/java/HelloWorld.xtend').content = '''
+			class HelloWorld {}
+		'''
+
+		// when
+		build('build')
+
+		// then
+		file('build/classes/main/HelloWorld.class').shouldExist
+	}
+	
+	@Test
+	def void classFilesAdhereToPackageStructure() {
+		// given
+		file('src/main/java/com/example/HelloWorld.xtend').content = '''
+			package com.example
+			class HelloWorld {}
+		'''
+
+		// when
+		build('build')
+
+		// then
+		file('build/classes/main/com/example/HelloWorld.class').shouldExist
+	}
 
 }
 

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingASimpleXtendProject.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingASimpleXtendProject.xtend
@@ -102,5 +102,33 @@ class BuildingASimpleXtendProject extends AbstractIntegrationTest {
 
 		build("generateXtext")
 	}
+	
+	@Test
+	def void shouldCompileAfterErrorIsFixed() {
+		// given
+		val file = createFile('src/main/java/HelloWorld.xtend', '''
+			class HelloWorld {
+				
+				def void helloWorld() {
+					println "This is Groovy syntax"
+				}
+				
+			}
+		''')
+		buildAndFail('build')
+		
+		// expect: no failure
+		file.content = '''
+			class HelloWorld {
+				
+				def void helloWorld() {
+					println("This is Xtend syntax")
+				}
+				
+			}
+		'''
+		build('build')
+	}
+
 }
 

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingASimpleXtendProject.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingASimpleXtendProject.xtend
@@ -6,13 +6,7 @@ class BuildingASimpleXtendProject extends AbstractIntegrationTest {
 
 	override setup() {
 		super.setup
-		buildFile << '''
-			apply plugin: 'org.xtext.xtend'
-			
-			dependencies {
-				compile 'org.eclipse.xtend:org.eclipse.xtend.lib:2.9.0-SNAPSHOT'
-			}
-		'''
+		buildFile << xtendPluginSnippet
 	}
 
 	@Test

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingASimpleXtendProject.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingASimpleXtendProject.xtend
@@ -2,12 +2,7 @@ package org.xtext.gradle.test
 
 import org.junit.Test
 
-class BuildingASimpleXtendProject extends AbstractIntegrationTest {
-
-	override setup() {
-		super.setup
-		buildFile << xtendPluginSnippet
-	}
+class BuildingASimpleXtendProject extends AbstractXtendIntegrationTest {
 
 	@Test
 	def theGeneratorShouldRunOnValidInput() {

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingASimpleXtendProjectWithStandardCharsets.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingASimpleXtendProjectWithStandardCharsets.xtend
@@ -14,7 +14,7 @@ import org.xtext.gradle.tasks.XtextGenerate
 import static java.nio.charset.StandardCharsets.*
 
 @RunWith(Parameterized)
-class BuildingASimpleXtendProjectWithStandardCharsets extends AbstractIntegrationTest {
+class BuildingASimpleXtendProjectWithStandardCharsets extends AbstractXtendIntegrationTest {
 
 	@Parameters(name="{0}")
 	static def Collection<Object[]> standardCharsets() {

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingASimpleXtendProjectWithStandardCharsets.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingASimpleXtendProjectWithStandardCharsets.xtend
@@ -1,0 +1,56 @@
+package org.xtext.gradle.test
+
+import com.google.common.io.Files
+import java.nio.charset.Charset
+import java.util.Collection
+import org.gradle.api.tasks.compile.JavaCompile
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameter
+import org.junit.runners.Parameterized.Parameters
+import org.xtext.gradle.tasks.XtextGenerate
+
+import static java.nio.charset.StandardCharsets.*
+
+@RunWith(Parameterized)
+class BuildingASimpleXtendProjectWithStandardCharsets extends AbstractIntegrationTest {
+
+	@Parameters(name="{0}")
+	static def Collection<Object[]> standardCharsets() {
+		return #[
+			#[US_ASCII],
+			#[ISO_8859_1],
+			#[UTF_8],
+			#[UTF_16BE],
+			#[UTF_16LE],
+			#[UTF_16]
+		]
+	}
+
+	@Parameter
+	public Charset charset
+
+	@Test
+	def void canCompileWithCharset() {
+		// given
+		buildFile << '''
+			«xtendPluginSnippet»
+			tasks.withType(«XtextGenerate.name») {
+				encoding = "«charset.name»"
+			}
+			tasks.withType(«JavaCompile.name») {
+				options.encoding = "«charset.name»"
+			}
+		'''
+		file('src/main/java/HelloWorld.xtend') => [
+			parentFile.mkdirs
+			createNewFile
+			Files.write('''class HelloWorld {}''', it, charset)
+		]
+
+		// expect: no error
+		build('build')
+	}
+
+}

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/GradleBuildTester.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/GradleBuildTester.xtend
@@ -10,6 +10,7 @@ import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.BuildTask
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.testkit.runner.internal.DefaultGradleRunner
 import org.junit.rules.ExternalResource
 import org.junit.rules.TemporaryFolder
 
@@ -28,6 +29,7 @@ class GradleBuildTester extends ExternalResource {
 			owner = this
 		]
 		gradle = GradleRunner.create.withProjectDir(rootProject.projectDir)
+		(gradle as DefaultGradleRunner).withJvmArguments('-Xmx512m', '-XX:MaxPermSize=512m')
 	}
 
 	override protected after() {

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/WhenSettingsChange.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/WhenSettingsChange.xtend
@@ -21,15 +21,7 @@ class WhenSettingsChange extends AbstractIntegrationTest {
 				options.encoding = "UTF-8"
 			}
 		'''
-		createFile('src/main/java/HelloWorld.xtend', '''
-			class HelloWorld {
-				
-				def void helloWorld() {
-					#['hello', 'world'].forEach[println(toFirstUpper)]
-				}
-				
-			}
-		''')
+		createXtendHelloWorld
 		build('build').xtextTask.shouldNotBeUpToDate
 		build('build').xtextTask.shouldBeUpToDate
 	}

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/WhenSettingsChange.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/WhenSettingsChange.xtend
@@ -2,34 +2,53 @@ package org.xtext.gradle.test
 
 import org.junit.Ignore
 import org.junit.Test
+import org.xtext.gradle.tasks.XtextGenerate
+import org.gradle.api.tasks.compile.JavaCompile
 
 class WhenSettingsChange extends AbstractIntegrationTest {
 
 	override setup() {
 		super.setup
-		buildFile << xtendPluginSnippet
-	}
-
-	@Test @Ignore
-	def void shouldRecompileWhenSettingsChange() {
-		// given
+		buildFile << '''
+			«xtendPluginSnippet»
+			xtext {
+				languages.xtend.generator.javaSourceLevel = "1.7"
+			}
+			tasks.withType(«XtextGenerate.name») {
+				encoding = "UTF-8"
+			}
+			tasks.withType(«JavaCompile.name») {
+				options.encoding = "UTF-8"
+			}
+		'''
 		createFile('src/main/java/HelloWorld.xtend', '''
 			class HelloWorld {
 				
 				def void helloWorld() {
 					#['hello', 'world'].forEach[println(toFirstUpper)]
-				}		
+				}
 				
 			}
 		''')
-		buildFile << '''
-			xtext.languages.xtend.generator.javaSourceLevel = "1.7"
-		'''
 		build('build').xtextTask.shouldNotBeUpToDate
 		build('build').xtextTask.shouldBeUpToDate
-		
+	}
+
+	@Test
+	def void shouldRecompileWhenEncodingChanges() {
 		// when
-		buildFile.content = buildFile.contentAsString.replace('''javaSourceLevel = "1.7"''', '''javaSourceLevel = "1.8"''')
+		buildFile.content = buildFile.contentAsString.replace('''encoding = "UTF-8"''', '''encoding = "ISO-8859-1"''')
+		val result = build('build')
+
+		// then
+		result.xtextTask.shouldNotBeUpToDate
+	}
+
+	@Test @Ignore
+	def void shouldRecompileWhenLanguageSettingsChange() {
+		// when
+		buildFile.content = buildFile.contentAsString.
+			replace('''javaSourceLevel = "1.7"''', '''javaSourceLevel = "1.8"''')
 		val result = build('build')
 
 		// then

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/WhenSettingsChange.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/WhenSettingsChange.xtend
@@ -7,13 +7,7 @@ class WhenSettingsChange extends AbstractIntegrationTest {
 
 	override setup() {
 		super.setup
-		buildFile << '''
-			apply plugin: 'org.xtext.xtend'
-			
-			dependencies {
-				compile 'org.eclipse.xtend:org.eclipse.xtend.lib:2.9.0-SNAPSHOT'
-			}
-		'''
+		buildFile << xtendPluginSnippet
 	}
 
 	@Test @Ignore

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/WhenSettingsChange.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/WhenSettingsChange.xtend
@@ -1,16 +1,15 @@
 package org.xtext.gradle.test
 
+import org.gradle.api.tasks.compile.JavaCompile
 import org.junit.Ignore
 import org.junit.Test
 import org.xtext.gradle.tasks.XtextGenerate
-import org.gradle.api.tasks.compile.JavaCompile
 
-class WhenSettingsChange extends AbstractIntegrationTest {
+class WhenSettingsChange extends AbstractXtendIntegrationTest {
 
 	override setup() {
 		super.setup
 		buildFile << '''
-			«xtendPluginSnippet»
 			xtext {
 				languages.xtend.generator.javaSourceLevel = "1.7"
 			}
@@ -21,7 +20,7 @@ class WhenSettingsChange extends AbstractIntegrationTest {
 				options.encoding = "UTF-8"
 			}
 		'''
-		createXtendHelloWorld
+		createHelloWorld
 		build('build').xtextTask.shouldNotBeUpToDate
 		build('build').xtextTask.shouldBeUpToDate
 	}


### PR DESCRIPTION
This adds a couple of integration tests for:
- Compiling after an error was fixed
- Existence of class files
- Recompilation (UP-TO-DATE status) when the encoding settings change
- Compiling with all standard encodings
- Compiling with different validation settings
- Compiling with Java 7 and 8

Note that the Java 7 test is ignored since it fails when executed with a Java 8 JDK (the generated code does not contain a lambda but uses `java.util.function.Consumer`). The test for Java 8 won't run with the current Travis configuration, we would need to add a second JDK (it therefore uses an assume-clause).