### PR TITLE
to use the gradle generated ideaRepository

### DIFF
--- a/xtext-idea-gradle-plugin/src/main/java/org/xtext/gradle/idea/tasks/IdeaRepository.xtend
+++ b/xtext-idea-gradle-plugin/src/main/java/org/xtext/gradle/idea/tasks/IdeaRepository.xtend
@@ -25,7 +25,7 @@ class IdeaRepository extends Sync {
 				«FOR it : files»
 					<plugin
 						id="«name.substring(0, name.indexOf('-'))»"
-						url="«rootUrl»/«name»"
+						url="file://«rootUrl»/«name»"
 						version="«name.substring(name.indexOf('-') + 1, name.lastIndexOf('.'))»"
 					/>
 				«ENDFOR»


### PR DESCRIPTION
it should setup the URL with protocol file://  so I could use it directly via Gradle like this:

ideaDevelopment {
	pluginRepositories {
		url "http://download.eclipse.org/modeling/tmf/xtext/idea/${xtextVersion}/updatePlugins.xml"
        url "file://localhost${parentPathDsl}mydsl/mydsl.parent/mydsl.idea/build/ideaRepository/updatePlugins.xml"
        url "file://localhost${parentPathDsl}yourdsl/yourdsl.parent/yourdsl.idea/build/ideaRepository/updatePlugins.xml"
	}
	pluginDependencies {
		id 'org.eclipse.xtext.idea' version xtextVersion
        id 'mydsl.idea' version '1.0.0-SNAPSHOT'
        id 'yourdsl.idea' version '1.0.0-SNAPSHOT'
	}
}