### PR TITLE
Fix for issue Xtendroid #128 and xtext-android-gradle-plugin #43

### DIFF
--- a/xtext-android-gradle-plugin/src/main/java/org/xtext/gradle/android/XtextAndroidBuilderPlugin.xtend
+++ b/xtext-android-gradle-plugin/src/main/java/org/xtext/gradle/android/XtextAndroidBuilderPlugin.xtend
@@ -38,10 +38,6 @@ class XtextAndroidBuilderPlugin implements Plugin<Project> {
 	private def configureAndroid() {
 		project.afterEvaluate[
 			android = project.extensions.getByName("android") as BaseExtension
-			android.packagingOptions [
-				exclude('META-INF/ECLIPSE_.RSA')
-				exclude('META-INF/ECLIPSE_.SF')
-			]
 			variants = switch android {
 				AppExtension: android.applicationVariants as DomainObjectSet<? extends BaseVariant>
 				LibraryExtension: android.libraryVariants
@@ -50,7 +46,12 @@ class XtextAndroidBuilderPlugin implements Plugin<Project> {
 			configureOutletDefaults
 			configureGeneratorDefaults
 			configureSourceSetDefaults
+			excludeMetaFiles
 		]
+	}
+
+	private def excludeMetaFiles() {
+		android.packagingOptions.excludes += 'META-INF/ECLIPSE_.*'
 	}
 
 	private def configureSourceSetDefaults() {


### PR DESCRIPTION
This fixes this issue:
```
      > Android tasks have already been created.
        This happens when calling android.applicationVariants,
        android.libraryVariants or android.testVariants.
        Once these methods are called, it is not possible to
        continue configuring the model.
```

That occurs after all versions from 1.0.9 onwards.

Thanks