### PR TITLE
[#107] Update gradle to 4.3 and maximum Xtext to 2.14.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,9 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'org.xtext:xtext-gradle-plugin:1.0.14'
-    classpath 'com.github.oehme.sobula:sobula:0.6.6'
-    classpath 'com.netflix.nebula:nebula-project-plugin:3.3.0'
+    classpath 'org.xtext:xtext-gradle-plugin:1.0.21'
+    classpath 'com.github.oehme.sobula:sobula:0.6.7'
+    classpath 'com.netflix.nebula:nebula-project-plugin:4.0.1'
   }
 }
 
@@ -35,7 +35,7 @@ subprojects {
   apply plugin: 'eclipse'
   apply plugin: 'java'
 
-  sourceCompatibility = 1.7
+  sourceCompatibility = 1.8
 
   tasks.withType(JavaCompile) {
       options.encoding = 'UTF-8'
@@ -43,9 +43,9 @@ subprojects {
 
   dependencies {
     compile gradleApi()
-    compile 'com.google.guava:guava:18.0'
+    compile 'com.google.guava:guava:21.0'
     testCompile 'junit:junit:4.12'
-    testCompile 'org.ow2.asm:asm:5.0.1'
+    testCompile 'org.ow2.asm:asm:6.1.1'
   }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 minimumXtextVersion = 2.9.0
 #We can't use 2.11 while we still want Java 6 support
 bootstrapXtextVersion = 2.9.1
-latestXtextVersion = 2.11.0.RC1
+latestXtextVersion = 2.14.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.3-bin.zip

--- a/gradle/xtend-bootstrap.gradle
+++ b/gradle/xtend-bootstrap.gradle
@@ -19,7 +19,7 @@ configurations {
 
 dependencies {
 	xtendCompiler "org.eclipse.xtend:org.eclipse.xtend.core"
-	xtendCompiler "org.xtext:xtext-gradle-builder:1.0.14"
+	xtendCompiler "org.xtext:xtext-gradle-builder:1.0.21"
 }
 
 subprojects {

--- a/xtext-android-gradle-plugin/src/main/java/org/xtext/gradle/android/XtextAndroidBuilderPlugin.xtend
+++ b/xtext-android-gradle-plugin/src/main/java/org/xtext/gradle/android/XtextAndroidBuilderPlugin.xtend
@@ -7,7 +7,6 @@ import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.LibraryPlugin
 import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.internal.api.TestedVariant
-import java.io.File
 import org.gradle.api.DomainObjectSet
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
@@ -60,7 +59,7 @@ class XtextAndroidBuilderPlugin implements Plugin<Project> {
 		variants.all [ variant |
 			configureSourceSetForVariant(variant)
 			if (variant instanceof TestedVariant) {
-				if (variant.testVariant != null)
+				if (variant.testVariant !== null)
 					configureSourceSetForVariant(variant.testVariant)
 			}
 		]
@@ -86,13 +85,13 @@ class XtextAndroidBuilderPlugin implements Plugin<Project> {
 			]
 			sourceDirs += variant.outputs.map[processResources.sourceOutputDir]
 			sourceSet.srcDirs(sourceDirs)
-			generatorTask.bootClasspath = android.bootClasspath.join(File.pathSeparator)
+			generatorTask.bootstrapClasspath = project.files(android.bootClasspath)
 			if (variant.javaCompiler instanceof AbstractCompile) {
 				val compile = variant.javaCompiler as AbstractCompile
 				generatorTask.classpath = compile.classpath.plus(
 						project.files(android.bootClasspath)
 				)
-				generatorTask.classesDir = compile.destinationDir
+				generatorTask.classesDirs = project.files(compile.destinationDir)
 				generatorTask.options.encoding = android.compileOptions.encoding
 				variant.registerJavaGeneratingTask(generatorTask, generatorTask.outputDirectories)
 			} else {

--- a/xtext-gradle-builder/src/main/java/org/xtext/gradle/builder/DebugInfoInstaller.xtend
+++ b/xtext-gradle-builder/src/main/java/org/xtext/gradle/builder/DebugInfoInstaller.xtend
@@ -50,17 +50,21 @@ class DebugInfoInstaller {
 
 	def private void installDebugInfo(InstallDebugInfoRequest request, File javaFile, JvmGenericType type, AbstractTraceRegion trace) throws IOException {
 		val relativePath = '''«type.qualifiedName.replace(".", File.separator)».class'''
-		val classFile = new File(request.classesDir, relativePath)
-		installDebugInfo(request, javaFile, classFile, trace)
-		for (member : type.members.filter(JvmGenericType)) {
-			installDebugInfo(request, javaFile, member, trace)
+		for (classesDir : request.classesDirs) {
+			val classFile = new File(classesDir, relativePath)
+			if (classFile.exists) {
+				installDebugInfo(request, javaFile, classFile, trace)
+				for (member : type.members.filter(JvmGenericType)) {
+					installDebugInfo(request, javaFile, member, trace)
+				}
+			}
 		}
 	}
 
 	def private void installDebugInfo(InstallDebugInfoRequest request, File javaFile, File classFile, AbstractTraceRegion trace) throws IOException {
 		val traceToBytecodeInstaller = createTraceToBytecodeInstaller(request, trace.associatedSrcRelativePath)
 		traceToBytecodeInstaller.setTrace(javaFile.name, trace)
-		val outputFile = new File(classFile.absolutePath.replace(request.classesDir.absolutePath, request.outputDir.absolutePath))
+		val outputFile = classFile
 		logger.info('''Installing Xtext debug information into «classFile» using «traceToBytecodeInstaller.class.simpleName»''')
 		outputFile.parentFile.mkdirs
 		val classContent = Files.toByteArray(classFile)

--- a/xtext-gradle-builder/src/main/java/org/xtext/gradle/builder/GradleResourceDescriptions.xtend
+++ b/xtext-gradle-builder/src/main/java/org/xtext/gradle/builder/GradleResourceDescriptions.xtend
@@ -23,7 +23,7 @@ class GradleResourceDescriptions extends ChunkedResourceDescriptions {
 	override getResourceDescription(URI uri) {
 		for (selectable : visibleResourceDescriptions) {
 			val result = selectable.getResourceDescription(uri)
-			if (result != null)
+			if (result !== null)
 				return result
 		}
 		return null

--- a/xtext-gradle-builder/src/main/java/org/xtext/gradle/builder/InstallDebugInfoRequest.xtend
+++ b/xtext-gradle-builder/src/main/java/org/xtext/gradle/builder/InstallDebugInfoRequest.xtend
@@ -5,13 +5,13 @@ import java.util.Collection
 import java.util.Map
 import org.eclipse.emf.ecore.resource.ResourceSet
 import org.eclipse.xtend.lib.annotations.Accessors
+import org.gradle.api.file.FileCollection
 
 //TODO move to Xtext
 @Accessors
 class InstallDebugInfoRequest {
 	Collection<File> generatedJavaFiles = newArrayList
-	File classesDir
-	File outputDir
+	FileCollection classesDirs
 	Map<String, SourceInstallerConfig> sourceInstallerByFileExtension = newHashMap
 	ResourceSet resourceSet
 

--- a/xtext-gradle-builder/src/main/java/org/xtext/gradle/builder/XtextGradleBuilder.xtend
+++ b/xtext-gradle-builder/src/main/java/org/xtext/gradle/builder/XtextGradleBuilder.xtend
@@ -190,14 +190,14 @@ class XtextGradleBuilder implements IncrementalXtextBuilder {
 	}
 	
 	private def boolean needsCleanBuild(GradleBuildRequest request) {
-		!request.incremental || !request.dirtyClasspathEntries.isEmpty || index.getContainer(request.containerHandle) == null
+		!request.incremental || !request.dirtyClasspathEntries.isEmpty || index.getContainer(request.containerHandle) === null
 	}
 	
 	private def getJvmTypesLoader(GradleBuildRequest gradleRequest) {
-		val parent = if (gradleRequest.bootClasspath === null) {
+		val parent = if (gradleRequest.bootstrapClasspath === null || gradleRequest.bootstrapClasspath.empty) {
 			ClassLoader.systemClassLoader
 		} else {
-			new AlternateJdkLoader(gradleRequest.bootClasspath.split(File.pathSeparator).map[new File(it)])
+			new AlternateJdkLoader(gradleRequest.bootstrapClasspath)
 		}
 		new URLClassLoader(gradleRequest.allClasspathEntries.map[toURI.toURL], parent)
 	}
@@ -268,8 +268,7 @@ class XtextGradleBuilder implements IncrementalXtextBuilder {
 	
 	override void installDebugInfo(GradleInstallDebugInfoRequest gradleRequest) {
 		val request = new InstallDebugInfoRequest => [
-			classesDir = gradleRequest.classesDir
-			outputDir =gradleRequest.classesDir
+			classesDirs = gradleRequest.classesDirs
 			sourceInstallerByFileExtension = gradleRequest.sourceInstallerByFileExtension.mapValues[gradleConfig|
 				new SourceInstallerConfig => [
 					sourceInstaller = SourceInstaller.valueOf(gradleConfig.sourceInstaller.name)

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingASimpleXtendProject.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingASimpleXtendProject.xtend
@@ -170,7 +170,7 @@ class BuildingASimpleXtendProject extends AbstractXtendIntegrationTest {
 		build('build')
 
 		// then
-		file('build/classes/main/HelloWorld.class').shouldExist
+		file('build/classes/java/main/HelloWorld.class').shouldExist
 	}
 	
 	@Test
@@ -185,7 +185,7 @@ class BuildingASimpleXtendProject extends AbstractXtendIntegrationTest {
 		build('build')
 
 		// then
-		file('build/classes/main/com/example/HelloWorld.class').shouldExist
+		file('build/classes/java/main/com/example/HelloWorld.class').shouldExist
 	}
 	
 	@Test
@@ -204,7 +204,7 @@ class BuildingASimpleXtendProject extends AbstractXtendIntegrationTest {
 
 		// then
 		file('build/xtend-gen/com/example/HelloWorld.java').shouldExist
-		file('build/classes/main/com/example/HelloWorld.class').shouldExist
+		file('build/classes/java/main/com/example/HelloWorld.class').shouldExist
 	}
 	
     @Test

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingAgainstDifferentXtextVersions.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/BuildingAgainstDifferentXtextVersions.xtend
@@ -1,0 +1,63 @@
+package org.xtext.gradle.test
+
+import org.junit.Test
+
+class BuildingAgainstDifferentXtextVersions extends AbstractIntegrationTest {
+
+	@Test def theGeneratorShouldRunOn_Xtext_2_9_0() { assertBuildWithXtext("2.9.0") }
+
+	@Test def theGeneratorShouldRunOn_Xtext_2_9_1() { assertBuildWithXtext("2.9.1") }
+
+	@Test def theGeneratorShouldRunOn_Xtext_2_9_2() { assertBuildWithXtext("2.9.2") }
+
+	@Test def theGeneratorShouldRunOn_Xtext_2_10_0() { assertBuildWithXtext("2.10.0") }
+
+	@Test def theGeneratorShouldRunOn_Xtext_2_11_0() { assertBuildWithXtext("2.11.0") }
+
+	@Test def theGeneratorShouldRunOn_Xtext_2_12_0() { assertBuildWithXtext("2.12.0") }
+
+	@Test def theGeneratorShouldRunOn_Xtext_2_13_0() { assertBuildWithXtext("2.13.0") }
+
+	@Test def theGeneratorShouldRunOn_Xtext_2_14_0() { assertBuildWithXtext("2.14.0") }
+
+	private def assertBuildWithXtext(String xtextVersion) {
+		buildFile << '''
+			apply plugin: 'org.xtext.builder'
+			
+			configurations {
+				compile
+			}
+			
+			dependencies {
+				compile 'org.eclipse.xtend:org.eclipse.xtend.lib:«xtextVersion»'
+				xtextLanguages 'org.eclipse.xtend:org.eclipse.xtend.core:«xtextVersion»'
+			}
+			
+			xtext {
+				version = '«xtextVersion»'
+				languages {
+					xtend {
+						setup = 'org.eclipse.xtend.core.XtendStandaloneSetup'
+					}
+				}
+				sourceSets {
+					main {
+						srcDir 'src/main/xtend'
+					}
+				}
+			}
+			
+			generateXtext.classpath = configurations.compile
+		'''
+
+		file('src/main/xtend/HelloWorld.xtend').content = '''
+			class HelloWorld {}
+		'''
+
+		build("generateXtext")
+
+		file('build/xtend/main/HelloWorld.java').shouldExist
+		file('build/xtend/main/.HelloWorld.java._trace').shouldExist
+	}
+
+}

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/WhenConfiguringTheDebuggerSupport.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/WhenConfiguringTheDebuggerSupport.xtend
@@ -71,7 +71,7 @@ class WhenConfiguringTheDebuggerSupport extends AbstractIntegrationTest {
 		''')
 		
 		build("build")
-		val classFile = file("build/classes/main/HelloWorld.class")
+		val classFile = file("build/classes/java/main/HelloWorld.class")
 		
 		classFile.shouldExist
 		new ClassReader(classFile.content).accept(new ClassVisitor(Opcodes.ASM5) {

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/WhenUsingXtendForProductionAndForTests.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/WhenUsingXtendForProductionAndForTests.xtend
@@ -1,0 +1,26 @@
+package org.xtext.gradle.test
+
+import org.junit.Test
+
+class WhenUsingXtendForProductionAndForTests extends AbstractXtendIntegrationTest {
+
+	@Test
+	def buildShouldCreateFilesInOutputFoldersAsDefinedbySourceSets() {
+		file('src/main/java/HelloWorld.xtend').content = '''
+			public class HelloWorld {}
+		'''
+
+		file('src/test/java/HelloWorldTest.xtend').content = '''
+			class HelloWorldTest {
+				val HelloWorld = new HelloWorld
+			}
+		'''
+
+		build("build")
+
+		file('build/xtend/main/HelloWorld.java').shouldExist
+		file('build/classes/java/main/HelloWorld.class').shouldExist
+		file('build/xtend/test/HelloWorldTest.java').shouldExist
+		file('build/classes/java/test/HelloWorldTest.class').shouldExist
+	}
+}

--- a/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/WhenUsingXtextForProductionAndXtendForTests.xtend
+++ b/xtext-gradle-plugin/src/integTest/java/org/xtext/gradle/test/WhenUsingXtextForProductionAndXtendForTests.xtend
@@ -1,0 +1,60 @@
+package org.xtext.gradle.test
+
+import org.junit.Test
+
+class WhenUsingXtextForProductionAndXtendForTests extends AbstractIntegrationTest {
+
+	override setup() {
+		super.setup
+		buildFile << '''
+			apply plugin: 'java'
+			apply plugin: 'org.xtext.xtend'
+			apply plugin: 'org.xtext.builder'
+			
+			configurations {
+				compile
+			}
+			
+			dependencies {
+				compile 'org.eclipse.xtend:org.eclipse.xtend.lib:«XTEXT_VERSION»'
+				xtextLanguages 'org.eclipse.xtend:org.eclipse.xtend.core:«XTEXT_VERSION»'
+			}
+			
+			xtext {
+				version = '«XTEXT_VERSION»'
+				languages {
+					xtend {
+						setup = 'org.eclipse.xtend.core.XtendStandaloneSetup'
+					}
+				}
+				sourceSets {
+					main {
+						srcDir 'src/main/xtend'
+					}
+					test {
+						srcDir 'src/test/xtend'
+					}
+				}
+			}
+			
+			generateXtext.classpath = configurations.compile
+		'''
+	}
+
+	@Test def buildShouldCreateJavaFilesInOutputFoldersAsDefinedbySourceSets() {
+		file('src/main/xtend/HelloWorld.xtend').content = '''
+			public class HelloWorld {}
+		'''
+
+		file('src/test/xtend/HelloWorldTest.xtend').content = '''
+			class HelloWorldTest {
+				val HelloWorld = new HelloWorld
+			}
+		'''
+
+		build("generateXtext", "test")
+
+		file('build/xtend/main/HelloWorld.java').shouldExist
+		file('build/xtend/test/HelloWorldTest.java').shouldExist
+	}
+}

--- a/xtext-gradle-plugin/src/main/java/org/xtext/gradle/XtendLanguageBasePlugin.xtend
+++ b/xtext-gradle-plugin/src/main/java/org/xtext/gradle/XtendLanguageBasePlugin.xtend
@@ -58,7 +58,7 @@ class XtendLanguageBasePlugin implements Plugin<Project> {
 					String version = null
 		
 					override apply() {
-						if (version == null) {
+						if (version === null) {
 							version = xtext.getXtextVersion(classpath) ?: xtext.getXtextVersion(xtextClasspath)
 							if (version === null) {
 								throw new GradleException('''Could not infer Xtext classpath, because xtext.version was not set and no xtext libraries were found on the «classpath» classpath''')

--- a/xtext-gradle-plugin/src/main/java/org/xtext/gradle/XtextBuilderPlugin.xtend
+++ b/xtext-gradle-plugin/src/main/java/org/xtext/gradle/XtextBuilderPlugin.xtend
@@ -52,11 +52,12 @@ class XtextBuilderPlugin implements Plugin<Project> {
 				sources = sourceSet
 				sourceSetOutputs = sourceSet.output
 				languages = xtext.languages
+				val XtextGenerate generate = it
 				xtextClasspath = project.files(new Callable<FileCollection>() {
 					FileCollection inferredClasspath
 					override call() throws Exception {
 						if (inferredClasspath === null) {
-							inferredClasspath = inferXtextClasspath(classpath)
+							inferredClasspath = inferXtextClasspath(generate.classpath)
 						}
 						inferredClasspath
 					}
@@ -160,8 +161,8 @@ class XtextBuilderPlugin implements Plugin<Project> {
 						}
 						generatorTask.options.encoding = generatorTask.options.encoding ?: javaCompile.options.encoding
 						generatorTask.classpath = generatorTask.classpath ?: javaSourceSet.compileClasspath
-						generatorTask.bootClasspath = generatorTask.bootClasspath ?: javaCompile.options.bootClasspath
-						generatorTask.classesDir = generatorTask.classesDir ?: javaSourceSet.output.classesDir
+						generatorTask.bootstrapClasspath = generatorTask.bootstrapClasspath ?: javaCompile.options.bootstrapClasspath
+						generatorTask.classesDirs = generatorTask.classesDirs ?: javaSourceSet.output.classesDirs
 					]
 				]
 			]

--- a/xtext-gradle-plugin/src/main/java/org/xtext/gradle/tasks/internal/IncrementalXtextBuilderProvider.xtend
+++ b/xtext-gradle-plugin/src/main/java/org/xtext/gradle/tasks/internal/IncrementalXtextBuilderProvider.xtend
@@ -18,7 +18,7 @@ class IncrementalXtextBuilderProvider {
 			if (incompatibleBuilderExists(languageSetups, encoding, xtextClasspath)) {
 				closeBuilder
 			}
-			if (builder == null) {
+			if (builder === null) {
 				createBuilder(languageSetups, encoding, xtextClasspath)
 			}
 			return builder;
@@ -26,7 +26,7 @@ class IncrementalXtextBuilderProvider {
 	}
 	
 	private static def incompatibleBuilderExists(Set<String> languageSetups, String encoding, Set<File> xtextClasspath) {
-		builder != null && getCheckSum(languageSetups, encoding, xtextClasspath) != builderChecksum
+		builder !== null && getCheckSum(languageSetups, encoding, xtextClasspath) != builderChecksum
 	}
 
 	private static def closeBuilder() {

--- a/xtext-gradle-plugin/src/main/java/org/xtext/gradle/tasks/internal/XtextEclipsePreferences.xtend
+++ b/xtext-gradle-plugin/src/main/java/org/xtext/gradle/tasks/internal/XtextEclipsePreferences.xtend
@@ -12,16 +12,16 @@ class XtextEclipsePreferences extends EclipsePreferences {
 	val File projectDir
 	val String language
 
-	override public getLocation() {
+	override getLocation() {
 		val path = new Path(projectDir.absolutePath)
 		computeLocation(path, language)
 	}
 
-	override public save() throws BackingStoreException {
+	override save() throws BackingStoreException {
 		super.save
 	}
 
-	override public load() throws BackingStoreException {
+	override load() throws BackingStoreException {
 		super.load
 	}
 }

--- a/xtext-gradle-protocol/src/main/java/org/xtext/gradle/protocol/GradleBuildRequest.java
+++ b/xtext-gradle-protocol/src/main/java/org/xtext/gradle/protocol/GradleBuildRequest.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.Collection;
 import java.util.Map;
 
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.logging.Logger;
 
 import com.google.common.collect.Lists;
@@ -20,7 +21,7 @@ public class GradleBuildRequest {
 	private Collection<File> deletedFiles = Lists.newArrayList();
 	private Collection<File> allClasspathEntries = Lists.newArrayList();
 	private Collection<File> dirtyClasspathEntries = Lists.newArrayList();
-	private String bootClasspath;
+	private FileCollection bootstrapClasspath;
 	private Collection<File> sourceFolders = Lists.newArrayList();
 	private Map<String, GradleGeneratorConfig> generatorConfigsByLanguage = Maps.newHashMap();
 	private Map<String, Map<String, String>> preferencesByLanguage = Maps.newHashMap();
@@ -58,12 +59,12 @@ public class GradleBuildRequest {
 		this.dirtyClasspathEntries = dirtyClasspathEntries;
 	}
 	
-	public String getBootClasspath() {
-		return bootClasspath;
+	public FileCollection getBootstrapClasspath() {
+		return bootstrapClasspath;
 	}
 	
-	public void setBootClasspath(String bootClasspath) {
-		this.bootClasspath = bootClasspath;
+	public void setBootstrapClasspath(FileCollection bootstrapClasspath) {
+		this.bootstrapClasspath = bootstrapClasspath;
 	}
 
 	public Collection<File> getDirtyFiles() {

--- a/xtext-gradle-protocol/src/main/java/org/xtext/gradle/protocol/GradleInstallDebugInfoRequest.java
+++ b/xtext-gradle-protocol/src/main/java/org/xtext/gradle/protocol/GradleInstallDebugInfoRequest.java
@@ -4,21 +4,23 @@ import java.io.File;
 import java.util.Collection;
 import java.util.Map;
 
+import org.gradle.api.file.FileCollection;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 public class GradleInstallDebugInfoRequest {
 
-	private File classesDir;
+	private FileCollection classesDirs;
 	private Collection<File> generatedJavaFiles = Lists.newArrayList();
 	private Map<String, GradleSourceInstallerConfig> sourceInstallerByFileExtension = Maps.newHashMap();
 
-	public File getClassesDir() {
-		return classesDir;
+	public FileCollection getClassesDirs() {
+		return classesDirs;
 	}
 
-	public void setClassesDir(File classesDir) {
-		this.classesDir = classesDir;
+	public void setClassesDirs(FileCollection classesDirs) {
+		this.classesDirs = classesDirs;
 	}
 	
 	public Map<String, GradleSourceInstallerConfig> getSourceInstallerByFileExtension() {


### PR DESCRIPTION
- Update versions of gradle, Xtext and libraries
- Fix build errors and test failures.
- Add tests to cover all relevant Xtext releases.
- Replace deprecated "classesDir" with "classesDirs".
- Replace deprecated "bootClasspath" with "bootstrapClasspath"

Signed-off-by: Arne Deutsch <Arne.Deutsch@itemis.de>