### PR TITLE
[#154] removed @Input from classesDirs to prevent task dependency cycles

### DIFF
--- a/xtext-gradle-plugin/src/main/java/org/xtext/gradle/tasks/XtextGenerate.xtend
+++ b/xtext-gradle-plugin/src/main/java/org/xtext/gradle/tasks/XtextGenerate.xtend
@@ -38,7 +38,7 @@ class XtextGenerate extends DefaultTask {
 
 	@Accessors @Input @Optional FileCollection bootstrapClasspath
 
-	@Accessors @Input @Optional FileCollection classesDirs
+	@Accessors @Optional FileCollection classesDirs // not marked with @Input intentionally
 
 	@Accessors XtextSourceSetOutputs sourceSetOutputs
 


### PR DESCRIPTION
[#154] removed @Input from classesDirs to prevent task dependency cycles
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>