### PR TITLE
Fix race condition in build script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ subprojects {
 
 configure(subprojects.findAll{p-> !p.name.contains('protocol')}) {
   apply plugin: 'org.xtext.xtend'
+  sourceJar.dependsOn generateXtext
 }
 
 apply from: "${rootDir}/gradle/xtend-bootstrap.gradle"


### PR DESCRIPTION
Hello

This commit fixes some ordering violations in build script. Specifically, the task `sourceJar` should depend on the task `generateXtext` so that it can create a jar file with the correct contents.

So, depending on the order in which gradle executes task, the contents of jar (e.g., `xtext-gradle-builder-sources.jar`) could be incorrect:

```
META-INF/
META-INF/MANIFEST.MF
META-INF/services/
META-INF/services/org.xtext.gradle.protocol.IncrementalXtextBuilderFactory
org/
org/xtext/
org/xtext/gradle/
org/xtext/gradle/builder/
org/xtext/gradle/builder/GradleProjectConfig.xtend
org/xtext/gradle/builder/GradleResourceDescriptions.xtend
org/xtext/gradle/builder/GradleValidatonCallback.xtend
org/xtext/gradle/builder/XtextGradleBuilder.xtend
org/xtext/gradle/builder/DebugInfoInstaller.xtend
org/xtext/gradle/builder/InstallDebugInfoRequest.xtend
org/xtext/gradle/builder/XtextGradleBuilderFactory.xtend
org/xtext/gradle/builder/GradleWorkspaceConfig.xtend
```

The correct contents of the this jar file are (this requires that the task `generateXtext` is executed **before** `sourceJar`).

```
META-INF/
META-INF/MANIFEST.MF
META-INF/services/
META-INF/services/org.xtext.gradle.protocol.IncrementalXtextBuilderFactory
org/
org/xtext/
org/xtext/gradle/
org/xtext/gradle/builder/
org/xtext/gradle/builder/GradleProjectConfig.xtend
org/xtext/gradle/builder/GradleResourceDescriptions.xtend
org/xtext/gradle/builder/GradleValidatonCallback.xtend
org/xtext/gradle/builder/XtextGradleBuilder.xtend
org/xtext/gradle/builder/DebugInfoInstaller.xtend
org/xtext/gradle/builder/InstallDebugInfoRequest.xtend
org/xtext/gradle/builder/XtextGradleBuilderFactory.xtend
org/xtext/gradle/builder/GradleWorkspaceConfig.xtend
org/xtext/gradle/builder/GradleResourceDescriptions.java
org/xtext/gradle/builder/.XtextGradleBuilder.java._trace
org/xtext/gradle/builder/.XtextGradleBuilderFactory.java._trace
org/xtext/gradle/builder/.GradleResourceDescriptions.java._trace
org/xtext/gradle/builder/.GradleWorkspaceConfig.java._trace
org/xtext/gradle/builder/GradleProjectConfig.java
org/xtext/gradle/builder/XtextGradleBuilder.java
org/xtext/gradle/builder/XtextGradleBuilderFactory.java
org/xtext/gradle/builder/GradleSourceFolder.java
org/xtext/gradle/builder/.GradleSourceFolder.java._trace
org/xtext/gradle/builder/.InstallDebugInfoRequest.java._trace
org/xtext/gradle/builder/DebugInfoInstaller.java
org/xtext/gradle/builder/.DebugInfoInstaller.java._trace
org/xtext/gradle/builder/.GradleValidatonCallback.java._trace
org/xtext/gradle/builder/.GradleProjectConfig.java._trace
org/xtext/gradle/builder/GradleValidatonCallback.java
org/xtext/gradle/builder/InstallDebugInfoRequest.java
org/xtext/gradle/builder/GradleWorkspaceConfig.java
```