### PR TITLE
make filtering dirty classpath entries nullsafe

### DIFF
--- a/xtext-gradle-builder/src/main/java/org/xtext/gradle/builder/XtextGradleBuilder.xtend
+++ b/xtext-gradle-builder/src/main/java/org/xtext/gradle/builder/XtextGradleBuilder.xtend
@@ -102,7 +102,7 @@ class XtextGradleBuilder implements IncrementalXtextBuilder {
 
 	private def indexChangedClasspathEntries(GradleBuildRequest gradleRequest) {
 		val registry = IResourceServiceProvider.Registry.INSTANCE
-		gradleRequest.dirtyClasspathEntries.filter[exists].forEach [ dirtyClasspathEntry |
+		gradleRequest.dirtyClasspathEntries.filterNull.filter[exists].forEach [ dirtyClasspathEntry |
 			val hash = hash(dirtyClasspathEntry)
 			if(dependencyHashes.get(dirtyClasspathEntry) != hash) {
 				val containerHandle = dirtyClasspathEntry.path


### PR DESCRIPTION
make filtering dirty classpath entries nullsafe

am not sure if this is a good idea or if there never should be any nulls in the first place